### PR TITLE
Implement dummy login screen

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,7 +42,8 @@
         "workbox-routing": "^6.6.0",
         "workbox-strategies": "^6.6.0",
         "workbox-streams": "^6.6.0",
-        "yup": "^1.6.1"
+        "yup": "^1.6.1",
+        "zod": "^3.24.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -16730,6 +16731,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "axios": "^1.7.9",
         "dexie": "^4.0.10",
         "dexie-react-hooks": "^1.1.7",
+        "jotai": "^2.12.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
@@ -10560,6 +10561,26 @@
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.12.1.tgz",
+      "integrity": "sha512-VUW0nMPYIru5g89tdxwr9ftiVdc/nGV9jvHISN8Ucx+m1vI9dBeHemfqYzEuw5XSkmYjD/MEyApN9k6yrATsZQ==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-tokens": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,8 @@
     "workbox-routing": "^6.6.0",
     "workbox-strategies": "^6.6.0",
     "workbox-streams": "^6.6.0",
-    "yup": "^1.6.1"
+    "yup": "^1.6.1",
+    "zod": "^3.24.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.7.9",
     "dexie": "^4.0.10",
     "dexie-react-hooks": "^1.1.7",
+    "jotai": "^2.12.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,25 +1,31 @@
-import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+// frontend/src/App.tsx
+import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
+import { Login } from './components/Login';
+
+const theme = createTheme({
+  components: {
+    MuiTextField: {
+      defaultProps: {
+        variant: 'outlined',
+        fullWidth: true
+      }
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none'
+        }
+      }
+    }
+  }
+});
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Login />
+    </ThemeProvider>
   );
 }
 

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -26,7 +26,7 @@ type FormValues = z.infer<typeof schema>;
 export const Login = () => {
   const [loginError, setLoginError] = useState('');
   const [loading, setLoading] = useState(false);
-  const setUser = useSetAtom(userAtom); // Using Jotai for global state
+  const setUser = useSetAtom(userAtom);
 
   const {
     register,
@@ -45,7 +45,6 @@ export const Login = () => {
     if (response.success) {
       setUser({ email: data.email, token: response.token || null });
       alert(response.message);
-      // Redirect to dashboard or home page here
     } else {
       setLoginError(response.message);
     }

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -11,7 +11,6 @@ import {
   Typography,
   Alert
 } from '@mui/material';
-import { DUMMY_CREDENTIALS } from '../constants/auth';
 
 const schema = z.object({
   email: z.string().email('Please enter a valid email address'),
@@ -19,6 +18,11 @@ const schema = z.object({
 });
 
 type FormValues = z.infer<typeof schema>;
+
+const DUMMY_CREDENTIALS = {
+  email: 'farmer@vikasa.org',
+  password: 'SecurePassword123!'
+};
 
 export const Login = () => {
   const [loginError, setLoginError] = useState('');
@@ -49,7 +53,7 @@ export const Login = () => {
         }}
       >
         <Typography component="h1" variant="h5">
-          Farmer Login
+          Login
         </Typography>
 
         <Box 

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,0 +1,100 @@
+// frontend/src/components/Login.tsx
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import {
+  Container,
+  Box,
+  TextField,
+  Button,
+  Typography,
+  Alert
+} from '@mui/material';
+import { DUMMY_CREDENTIALS } from '../constants/auth';
+
+const schema = z.object({
+  email: z.string().email('Please enter a valid email address'),
+  password: z.string().min(1, 'Password is required')
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export const Login = () => {
+  const [loginError, setLoginError] = useState('');
+  const { register, handleSubmit, formState: { errors } } = useForm<FormValues>({
+    resolver: zodResolver(schema)
+  });
+
+  const onSubmit = (data: FormValues) => {
+    if (data.email === DUMMY_CREDENTIALS.email && 
+        data.password === DUMMY_CREDENTIALS.password) {
+      // TODO: Replace with actual authentication logic
+      alert('Login successful!');
+      setLoginError('');
+    } else {
+      setLoginError('Invalid email or password');
+    }
+  };
+
+  return (
+    <Container maxWidth="xs">
+      <Box
+        sx={{
+          marginTop: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 2
+        }}
+      >
+        <Typography component="h1" variant="h5">
+          Farmer Login
+        </Typography>
+
+        <Box 
+          component="form" 
+          onSubmit={handleSubmit(onSubmit)}
+          sx={{ mt: 1, width: '100%' }}
+        >
+          {loginError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {loginError}
+            </Alert>
+          )}
+
+          <TextField
+            margin="normal"
+            fullWidth
+            label="Email Address"
+            autoComplete="email"
+            autoFocus
+            error={!!errors.email}
+            helperText={errors.email?.message}
+            {...register('email')}
+          />
+
+          <TextField
+            margin="normal"
+            fullWidth
+            label="Password"
+            type="password"
+            autoComplete="current-password"
+            error={!!errors.password}
+            helperText={errors.password?.message}
+            {...register('password')}
+          />
+
+          <Button
+            type="submit"
+            fullWidth
+            variant="contained"
+            sx={{ mt: 3, mb: 2 }}
+          >
+            Sign In
+          </Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+};

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,4 +1,3 @@
-// frontend/src/components/Login.tsx
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -9,9 +8,14 @@ import {
   TextField,
   Button,
   Typography,
-  Alert
+  Alert,
+  CircularProgress
 } from '@mui/material';
+import { useSetAtom } from 'jotai';
+import { userAtom } from '../store/authAtoms';
+import { authenticateUser } from '../utils/auth';
 
+// Validation Schema
 const schema = z.object({
   email: z.string().email('Please enter a valid email address'),
   password: z.string().min(1, 'Password is required')
@@ -19,26 +23,34 @@ const schema = z.object({
 
 type FormValues = z.infer<typeof schema>;
 
-const DUMMY_CREDENTIALS = {
-  email: 'farmer@vikasa.org',
-  password: 'SecurePassword123!'
-};
-
 export const Login = () => {
   const [loginError, setLoginError] = useState('');
-  const { register, handleSubmit, formState: { errors } } = useForm<FormValues>({
+  const [loading, setLoading] = useState(false);
+  const setUser = useSetAtom(userAtom); // Using Jotai for global state
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<FormValues>({
     resolver: zodResolver(schema)
   });
 
-  const onSubmit = (data: FormValues) => {
-    if (data.email === DUMMY_CREDENTIALS.email && 
-        data.password === DUMMY_CREDENTIALS.password) {
-      // TODO: Replace with actual authentication logic
-      alert('Login successful!');
-      setLoginError('');
+  const onSubmit = async (data: FormValues) => {
+    setLoading(true);
+    setLoginError('');
+
+    const response = await authenticateUser(data.email, data.password);
+
+    if (response.success) {
+      setUser({ email: data.email, token: response.token || null });
+      alert(response.message);
+      // Redirect to dashboard or home page here
     } else {
-      setLoginError('Invalid email or password');
+      setLoginError(response.message);
     }
+
+    setLoading(false);
   };
 
   return (
@@ -56,10 +68,17 @@ export const Login = () => {
           Login
         </Typography>
 
-        <Box 
-          component="form" 
+        <Box
+          component="form"
           onSubmit={handleSubmit(onSubmit)}
-          sx={{ mt: 1, width: '100%' }}
+          sx={{
+            mt: 1,
+            width: '100%',
+            padding: 2,
+            backgroundColor: 'background.paper',
+            borderRadius: 2,
+            boxShadow: 3
+          }}
         >
           {loginError && (
             <Alert severity="error" sx={{ mb: 2 }}>
@@ -93,9 +112,14 @@ export const Login = () => {
             type="submit"
             fullWidth
             variant="contained"
-            sx={{ mt: 3, mb: 2 }}
+            disabled={loading}
+            sx={{ mt: 3, mb: 2, height: 45, position: 'relative' }}
           >
-            Sign In
+            {loading ? (
+              <CircularProgress size={24} sx={{ color: 'white' }} />
+            ) : (
+              'Sign In'
+            )}
           </Button>
         </Box>
       </Box>

--- a/frontend/src/constants/auth.ts
+++ b/frontend/src/constants/auth.ts
@@ -1,5 +1,0 @@
-// frontend/src/constants/auth.ts
-export const DUMMY_CREDENTIALS = {
-  email: 'farmer@vikasa.org',
-  password: 'SecurePassword123!'
-};

--- a/frontend/src/constants/auth.ts
+++ b/frontend/src/constants/auth.ts
@@ -1,0 +1,5 @@
+// frontend/src/constants/auth.ts
+export const DUMMY_CREDENTIALS = {
+  email: 'farmer@vikasa.org',
+  password: 'SecurePassword123!'
+};

--- a/frontend/src/store/authAtoms.ts
+++ b/frontend/src/store/authAtoms.ts
@@ -1,0 +1,11 @@
+import { atom } from 'jotai';
+
+export const userAtom = atom<{ email: string | null; token: string | null }>({
+  email: null,
+  token: null
+});
+
+export const draftAtom = atom<{ email: string; password: string }>({
+  email: '',
+  password: ''
+});

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,0 +1,25 @@
+type LoginResponse = {
+    success: boolean;
+    message: string;
+    token?: string;
+};
+
+export const authenticateUser = async (email: string, password: string): Promise<LoginResponse> => {
+    // Dummy authentication logic for now
+    if (email === 'farmer@vikasa.org' && password === 'password123') {
+        return { success: true, message: 'Login Successful!', token: 'dummy-token-123' };
+    } else {
+        return { success: false, message: 'Invalid email or password' };
+    }
+};
+
+// // AWS Cognito placeholder function for future integration
+// export const authenticateWithAWS = async (email: string, password: string): Promise<LoginResponse> => {
+//     try {
+//         // Example AWS Cognito sign-in (pseudo-code)
+//         const response = await AWSCognitoClient.signIn(email, password);
+//         return { success: true, message: 'Login Successful!', token: response.token };
+//     } catch (error) {
+//         return { success: false, message: error.message || 'AWS Login Failed' };
+//     }
+// };


### PR DESCRIPTION
# Issue Reference
issue: #24 

# Summary

- Implemented a responsive login screen using MUI
- Added Jotai for state management (used userAtom to store auth state)
- Integrated React Hook Form with Zod for form validation
- Dummy authentication logic in authenticateUser (hardcoded credentials)
- Basic error handling & loading state (using useState)
- Mobile-friendly UI

# Screenshots
![image](https://github.com/user-attachments/assets/49c7352e-6e2a-4635-93b6-1e324191fdb2)


# Future Enhancements

- Integrate AWS Cognito once provisioned
- Improve UI based on feedback